### PR TITLE
Updated SectionCards and Navbar links

### DIFF
--- a/retroid-pocket5-hub/src/app/page.js
+++ b/retroid-pocket5-hub/src/app/page.js
@@ -1,7 +1,53 @@
-import Head from 'next/head';
-import { FaBook, FaMicrochip, FaCogs, FaListAlt, FaQuestionCircle, FaPuzzlePiece } from 'react-icons/fa';
+import Head from "next/head";
+import Link from "next/link";
+import {
+  FaBook,
+  FaMicrochip,
+  FaCogs,
+  FaListAlt,
+  FaQuestionCircle,
+  FaPuzzlePiece,
+} from "react-icons/fa";
 
 export default function Home() {
+  const sectionCards = [
+    {
+      title: "Guides",
+      description: "Step-by-step tutorials",
+      url: "/guides",
+      icon: FaBook,
+    },
+    {
+      title: "Emulation",
+      description: "Emulators and system configs",
+      url: "/emulation",
+      icon: FaMicrochip,
+    },
+    {
+      title: "Accessories",
+      description: "Recommended add-ons",
+      url: "/accessories",
+      icon: FaCogs,
+    },
+    {
+      title: "Specs",
+      description: "Technical specifications",
+      url: "/specs",
+      icon: FaListAlt,
+    },
+    {
+      title: "FAQs",
+      description: "Common questions answered",
+      url: "/faqs",
+      icon: FaQuestionCircle,
+    },
+    {
+      title: "Game Picks",
+      description: "Top Android games for RP5",
+      url: "/game-picks",
+      icon: FaPuzzlePiece,
+    },
+  ];
   return (
     <>
       <Head>
@@ -14,12 +60,18 @@ export default function Home() {
           name="keywords"
           content="Retroid Pocket 5, RP5, Retro Handheld, Tutorials, Videos, Firmware, Guides, Accessories, Specs, FAQs, Compatibility"
         />
-        <meta property="og:title" content="Retroid Pocket 5 Hub - Retro Handheld Tutorials & Videos" />
+        <meta
+          property="og:title"
+          content="Retroid Pocket 5 Hub - Retro Handheld Tutorials & Videos"
+        />
         <meta
           property="og:description"
           content="Your ultimate source for the best tutorials and videos on retro handhelds and the Retroid Pocket 5. Discover guides, firmwares, accessories, specs, FAQs and more."
         />
-        <meta property="og:url" content="https://retroid-pocket-5-hub.vercel.app/" />
+        <meta
+          property="og:url"
+          content="https://retroid-pocket-5-hub.vercel.app/"
+        />
         <meta property="og:type" content="website" />
         <meta property="og:image" content="/images/retroid-pocket-5.png" />
         <link rel="canonical" href="https://retroid-pocket-5-hub.vercel.app/" />
@@ -62,57 +114,29 @@ export default function Home() {
           </div>
         </div>
 
-
         {/* Tarjetas interactivas para explorar las secciones */}
         <div className="w-full">
           <h2 className="text-2xl font-bold text-retroBlue dark:text-retroPurple text-center mb-4">
             Explore the Sections
           </h2>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <SectionCard 
-              title="Guides" 
-              description="Step-by-step tutorials." 
-              link="/guides" 
-              Icon={FaBook}
-            />
-            <SectionCard 
-              title="Emulation" 
-              description="Emulators and system configs." 
-              link="/emulation" 
-              Icon={FaMicrochip}
-            />
-            <SectionCard 
-              title="Accessories" 
-              description="Recommended add-ons." 
-              link="/accessories" 
-              Icon={FaCogs}
-            />
-            <SectionCard 
-              title="Specs" 
-              description="Technical specifications." 
-              link="/specs" 
-              Icon={FaListAlt}
-            />
-            <SectionCard 
-              title="FAQs" 
-              description="Common questions answered." 
-              link="/faqs" 
-              Icon={FaQuestionCircle}
-            />
-            <SectionCard 
-              title="Game Picks" 
-              description="Top Android games for RP5." 
-              link="/game-picks" 
-              Icon={FaPuzzlePiece}
-            />
+            {sectionCards.map((c) => (
+              <SectionCard
+                key={c.url}
+                title={c.title}
+                description={c.description}
+                link={c.url}
+                Icon={c.icon}
+              />
+            ))}
           </div>
         </div>
-
 
         {/* Support Section */}
         <div className="flex flex-col items-center text-center space-y-4">
           <p className="text-xs text-gray-700 dark:text-gray-300">
-            Enjoying this project? Support me on YouTube, Ko‑fi, or by shopping on AliExpress at no extra cost!
+            Enjoying this project? Support me on YouTube, Ko‑fi, or by shopping
+            on AliExpress at no extra cost!
           </p>
           <div className="flex flex-col md:flex-row gap-3">
             <a
@@ -171,17 +195,14 @@ export default function Home() {
 
 function SectionCard({ title, description, link, Icon }) {
   return (
-    <a 
+    <Link
       href={link}
-      target="_blank"
-      rel="noopener noreferrer"
+      target="_self"
       className="block border-4 border-black p-4 bg-retroBlue text-white text-center retro-button hover:scale-105 transition-transform duration-150"
     >
-      {Icon && (
-        <Icon size={48} className="mx-auto mb-2" />
-      )}
+      {Icon && <Icon size={48} className="mx-auto mb-2" />}
       <h3 className="text-xl font-bold mb-1 break-words">{title}</h3>
       <p className="text-sm">{description}</p>
-    </a>
+    </Link>
   );
 }

--- a/retroid-pocket5-hub/src/components/Navbar.js
+++ b/retroid-pocket5-hub/src/components/Navbar.js
@@ -49,6 +49,13 @@ export default function Navbar() {
     };
   }, [moreOpen]);
 
+  const navItems = [
+    { label: "Guides", url: "/guides" },
+    { label: "Emulation", url: "/emulation" },
+    { label: "Game Picks", url: "/game-picks" },
+    { label: "Accessories", url: "/accessories" },
+  ];
+
   return (
     <header className="w-full bg-gray-800 text-white">
       <div className="max-w-5xl mx-auto px-4">
@@ -65,28 +72,21 @@ export default function Navbar() {
 
           {/* Menú Desktop */}
           <ul className="hidden md:flex gap-6 text-sm justify-center items-center whitespace-nowrap">
-            <li>
-              <Link href="/guides" className="hover:text-gray-400 px-2 whitespace-nowrap">
-                Guides
-              </Link>
-            </li>
-            <li>
-              <Link href="/emulation" className="hover:text-gray-400 px-2 whitespace-nowrap">
-                Emulation
-              </Link>
-            </li>
-            <li>
-              <Link href="/game-picks" className="hover:text-gray-400 px-2 whitespace-nowrap">
-                Game Picks
-              </Link>
-            </li>
-            <li>
-              <Link href="/accessories" className="hover:text-gray-400 px-2 whitespace-nowrap">
-                Accessories
-              </Link>
-            </li>
+            {navItems.map((item) => (
+              <li key={item.url}>
+                <Link
+                  href={item.url}
+                  className="hover:text-gray-400 px-2 whitespace-nowrap"
+                >
+                  {item.label}
+                </Link>
+              </li>
+            ))}
             <li className="relative" ref={moreRef}>
-              <button onClick={() => setMoreOpen(!moreOpen)} className="hover:text-gray-400 px-2 whitespace-nowrap">
+              <button
+                onClick={() => setMoreOpen(!moreOpen)}
+                className="hover:text-gray-400 px-2 whitespace-nowrap"
+              >
                 More ▾
               </button>
               {moreOpen && (
@@ -110,10 +110,12 @@ export default function Navbar() {
             </li>
           </ul>
 
-
           {/* Botón modo oscuro (Desktop) */}
           <div className="hidden md:flex items-center">
-            <button onClick={toggleDarkMode} className="retro-button px-3 py-1 text-xs ml-6">
+            <button
+              onClick={toggleDarkMode}
+              className="retro-button px-3 py-1 text-xs ml-6"
+            >
               {darkMode ? "☀️" : "🌙"}
             </button>
           </div>
@@ -132,32 +134,56 @@ export default function Navbar() {
         <div className="bg-gray-900 text-white px-4 py-4">
           <ul className="flex flex-col gap-4">
             <li>
-              <Link href="/guides" className="hover:text-gray-400" onClick={() => setMenuOpen(false)}>
+              <Link
+                href="/guides"
+                className="hover:text-gray-400"
+                onClick={() => setMenuOpen(false)}
+              >
                 Guides
               </Link>
             </li>
             <li>
-              <Link href="/emulation" className="hover:text-gray-400" onClick={() => setMenuOpen(false)}>
+              <Link
+                href="/emulation"
+                className="hover:text-gray-400"
+                onClick={() => setMenuOpen(false)}
+              >
                 Emulation
               </Link>
             </li>
             <li>
-              <Link href="/game-picks" className="hover:text-gray-400" onClick={() => setMenuOpen(false)}>
+              <Link
+                href="/game-picks"
+                className="hover:text-gray-400"
+                onClick={() => setMenuOpen(false)}
+              >
                 Game Picks
               </Link>
             </li>
             <li>
-              <Link href="/accessories" className="hover:text-gray-400" onClick={() => setMenuOpen(false)}>
+              <Link
+                href="/accessories"
+                className="hover:text-gray-400"
+                onClick={() => setMenuOpen(false)}
+              >
                 Accessories
               </Link>
             </li>
             <li>
-              <Link href="/faqs" className="hover:text-gray-400" onClick={() => setMenuOpen(false)}>
+              <Link
+                href="/faqs"
+                className="hover:text-gray-400"
+                onClick={() => setMenuOpen(false)}
+              >
                 FAQs
               </Link>
             </li>
             <li>
-              <Link href="/specs" className="hover:text-gray-400" onClick={() => setMenuOpen(false)}>
+              <Link
+                href="/specs"
+                className="hover:text-gray-400"
+                onClick={() => setMenuOpen(false)}
+              >
                 Specs
               </Link>
             </li>


### PR DESCRIPTION
- Replaced `target="_blank"` with `target="_self"` so relative links don't open in a new tab
- Consolidated SectionCard data to an array
- Consolidated Navbar links to an array

All I really wanted to do was remove the `target="_blank"` from the SectionCard components on the homepage, but I couldn't resist mapping the cards. Might be good to move the arrays to a config folder/file to clean up the page files.

There's still an issue with the Navbar/dark-mode button stretching the page out and between large and mobile.
The Navbar links are cut off and it causes the need to scroll horizontally. I started to fix it, but got bored. Just throwing that out there.

Also, sorry for all the changes due to formatting on the two files i touched. There was no prettier/whatever config so my default one took over.